### PR TITLE
Fix swagger error by changing webservices dependency version to imple…

### DIFF
--- a/omod/src/main/java/org/openmrs/module/reportingrest/web/resource/EvaluatedCohortResource.java
+++ b/omod/src/main/java/org/openmrs/module/reportingrest/web/resource/EvaluatedCohortResource.java
@@ -13,6 +13,10 @@
  */
 package org.openmrs.module.reportingrest.web.resource;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.Patient;
@@ -38,6 +42,7 @@ import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
+import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
 import java.util.ArrayList;
@@ -162,6 +167,57 @@ public class EvaluatedCohortResource extends EvaluatedResource<EvaluatedCohort> 
 		}
 
 		return description;
+	}
+
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep));
+		modelImpl.property("uuid", new StringProperty())
+				.property("renderingMode", new StringProperty())
+				.property("priority", new StringProperty())
+				.property("schedule", new StringProperty())
+				.property("requestedBy", new StringProperty())
+				.property("requestDate", new DateProperty())
+				.property("status", new StringProperty())
+				.property("evaluateStartDatetime", new DateProperty())
+				.property("evaluateCompleteDatetime", new DateProperty())
+				.property("renderCompleteDatetime", new DateProperty())
+				.property("description", new StringProperty());
+		return modelImpl;
+	}
+
+	@Override
+	public DelegatingResourceDescription getCreatableProperties() throws ResourceDoesNotSupportOperationException {
+		DelegatingResourceDescription delegatingResourceDescription = new DelegatingResourceDescription();
+		delegatingResourceDescription.addProperty("uuid");
+		delegatingResourceDescription.addProperty("renderingMode");
+		delegatingResourceDescription.addProperty("priority");
+		delegatingResourceDescription.addProperty("schedule");
+		delegatingResourceDescription.addProperty("requestedBy");
+		delegatingResourceDescription.addProperty("requestDate");
+		delegatingResourceDescription.addProperty("status");
+		delegatingResourceDescription.addProperty("evaluateStartDatetime");
+		delegatingResourceDescription.addProperty("evaluateCompleteDatetime");
+		delegatingResourceDescription.addProperty("renderCompleteDatetime");
+		delegatingResourceDescription.addProperty("description");
+		return delegatingResourceDescription;
+	}
+
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep));
+		modelImpl.property("uuid", new StringProperty())
+				.property("renderingMode", new StringProperty())
+				.property("priority", new StringProperty())
+				.property("schedule", new StringProperty())
+				.property("requestedBy", new StringProperty())
+				.property("requestDate", new DateProperty())
+				.property("status", new StringProperty())
+				.property("evaluateStartDatetime", new DateProperty())
+				.property("evaluateCompleteDatetime", new DateProperty())
+				.property("renderCompleteDatetime", new DateProperty())
+				.property("description", new StringProperty());
+		return modelImpl;
 	}
 
 	/**

--- a/omod/src/main/java/org/openmrs/module/reportingrest/web/resource/EvaluatedDataSetResource.java
+++ b/omod/src/main/java/org/openmrs/module/reportingrest/web/resource/EvaluatedDataSetResource.java
@@ -13,6 +13,9 @@
  */
 package org.openmrs.module.reportingrest.web.resource;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.Cohort;
@@ -40,6 +43,7 @@ import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentat
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
+import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 import org.springframework.util.StringUtils;
 
@@ -170,6 +174,38 @@ public class EvaluatedDataSetResource extends EvaluatedResource<DataSet> {
 		}
 
 		return description;
+	}
+
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep));
+		if (rep instanceof DefaultRepresentation) {
+			modelImpl.property("uuid", new StringProperty())
+					.property("metadata", new StringProperty())
+					.property("rows", new StringProperty())
+					.property("definition", new StringProperty());
+		}
+		return modelImpl;
+	}
+
+	@Override
+	public DelegatingResourceDescription getCreatableProperties() throws ResourceDoesNotSupportOperationException {
+		DelegatingResourceDescription delegatingResourceDescription = new DelegatingResourceDescription();
+		delegatingResourceDescription.addProperty("uuid");
+		delegatingResourceDescription.addProperty("metadata");
+		delegatingResourceDescription.addProperty("rows");
+		delegatingResourceDescription.addProperty("definition");
+		return delegatingResourceDescription;
+	}
+
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep));
+		modelImpl.property("uuid", new StringProperty())
+				.property("metadata", new StringProperty())
+				.property("rows", new StringProperty())
+				.property("definition", new StringProperty());
+		return modelImpl;
 	}
 
 	/**

--- a/omod/src/main/java/org/openmrs/module/reportingrest/web/resource/EvaluatedReportDefinitionResource.java
+++ b/omod/src/main/java/org/openmrs/module/reportingrest/web/resource/EvaluatedReportDefinitionResource.java
@@ -1,5 +1,8 @@
 package org.openmrs.module.reportingrest.web.resource;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
@@ -22,6 +25,7 @@ import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentat
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
+import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 import org.springframework.util.StringUtils;
 
@@ -52,6 +56,38 @@ public class EvaluatedReportDefinitionResource extends EvaluatedResource<ReportD
         }
 
         return description;
+    }
+
+    @Override
+    public Model getGETModel(Representation rep) {
+        ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep));
+        if (rep instanceof DefaultRepresentation) {
+            modelImpl.property("uuid", new StringProperty())
+                    .property("dataSets", new StringProperty())
+                    .property("context", new StringProperty())
+                    .property("definition", new StringProperty());
+        }
+        return modelImpl;
+    }
+
+    @Override
+    public DelegatingResourceDescription getCreatableProperties() throws ResourceDoesNotSupportOperationException {
+        DelegatingResourceDescription delegatingResourceDescription = new DelegatingResourceDescription();
+        delegatingResourceDescription.addProperty("uuid");
+        delegatingResourceDescription.addProperty("dataSets");
+        delegatingResourceDescription.addProperty("context");
+        delegatingResourceDescription.addProperty("definition");
+        return delegatingResourceDescription;
+    }
+
+    @Override
+    public Model getCREATEModel(Representation rep) {
+        ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep));
+        modelImpl.property("uuid", new StringProperty())
+                .property("dataSets", new StringProperty())
+                .property("context", new StringProperty())
+                .property("definition", new StringProperty());
+        return modelImpl;
     }
 
     @PropertyGetter("dataSets")
@@ -143,6 +179,11 @@ public class EvaluatedReportDefinitionResource extends EvaluatedResource<ReportD
         } catch (Exception ex) {
             throw new IllegalArgumentException("Error evaluating report definition", ex);
         }
+    }
+
+    @Override
+    public ReportData newDelegate() {
+        return new ReportData();
     }
 
 }

--- a/omod/src/main/java/org/openmrs/module/reportingrest/web/resource/ReportRequestResource.java
+++ b/omod/src/main/java/org/openmrs/module/reportingrest/web/resource/ReportRequestResource.java
@@ -12,6 +12,11 @@ package org.openmrs.module.reportingrest.web.resource;
 import java.util.List;
 import java.util.Map;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.context.Context;
@@ -103,6 +108,18 @@ public class ReportRequestResource extends DelegatingCrudResource<ReportRequest>
 		return delegatingResourceDescription;
 	}
 
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep));
+		modelImpl.property("status", new StringProperty())
+				.property("reportDefinition", new StringProperty())
+				.property("baseCohort", new StringProperty())
+				.property("renderingMode", new StringProperty())
+				.property("priority", new StringProperty())
+				.property("schedule", new StringProperty());
+		return modelImpl;
+	}
+
 	/**
 	 * @see BaseDelegatingResource#purge(Object, RequestContext)
 	 */
@@ -155,6 +172,38 @@ public class ReportRequestResource extends DelegatingCrudResource<ReportRequest>
 			description.addSelfLink();
 		}
 		return description;
+	}
+
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep));
+		if (rep instanceof DefaultRepresentation) {
+			modelImpl.property("uuid", new StringProperty())
+					.property("renderingMode", new StringProperty())
+					.property("priority", new StringProperty())
+					.property("schedule", new StringProperty())
+					.property("requestedBy", new StringProperty())
+					.property("requestDate", new DateProperty())
+					.property("status", new StringProperty())
+					.property("evaluateStartDatetime", new DateProperty())
+					.property("evaluateCompleteDatetime", new DateProperty())
+					.property("renderCompleteDatetime", new DateProperty())
+					.property("description", new StringProperty());
+		}
+		if (rep instanceof FullRepresentation) {
+			modelImpl.property("uuid", new StringProperty())
+					.property("renderingMode", new StringProperty())
+					.property("priority", new StringProperty())
+					.property("schedule", new StringProperty())
+					.property("requestedBy", new StringProperty())
+					.property("requestDate", new DateProperty())
+					.property("status", new StringProperty())
+					.property("evaluateStartDatetime", new DateProperty())
+					.property("evaluateCompleteDatetime", new DateProperty())
+					.property("renderCompleteDatetime", new DateProperty())
+					.property("description", new StringProperty());
+		}
+		return modelImpl;
 	}
 
 	/**

--- a/omod/src/test/java/org/openmrs/module/reportingrest/web/resource/EvaluatedCohortResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/reportingrest/web/resource/EvaluatedCohortResourceTest.java
@@ -164,7 +164,7 @@ public class EvaluatedCohortResourceTest extends BaseEvaluatedResourceTest<Evalu
 	private void assertCohortMembers(Object evaluated, String json, String[] expectedUuids) throws Exception {
 		assertEquals(expectedUuids.length, ((List) path(evaluated, "members")).size());
 		for (String expected : expectedUuids) {
-			assertTrue(json.contains("/patient/" + expected));
+			assertTrue(json.contains("/person/" + expected));
 		}
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <properties>
         <openMRSVersion>1.9.9</openMRSVersion>
-        <webservicesRestVersion>2.5</webservicesRestVersion>
+        <webservicesRestVersion>2.21.0</webservicesRestVersion>
         <reportingVersion>1.15.0</reportingVersion>
         <htmlwidgetsVersion>1.6.4</htmlwidgetsVersion>
         <serializationxstreamVersion>0.2.7</serializationxstreamVersion>


### PR DESCRIPTION
Fixing swagger API documentation errors by implementing the required methods. 
Changed webservices.rest dependency version to 2.21.0 to support the change.

Refer: https://talk.openmrs.org/t/error-in-swagger-api-documentation/33771