### PR TITLE
REPORT-879: Remove "class" property from BaseDefinitionResource

### DIFF
--- a/omod/src/main/java/org/openmrs/module/reportingrest/web/resource/BaseDefinitionResource.java
+++ b/omod/src/main/java/org/openmrs/module/reportingrest/web/resource/BaseDefinitionResource.java
@@ -96,8 +96,7 @@ public abstract class BaseDefinitionResource<T extends Definition> extends Metad
 		
 		if (rep instanceof DefaultRepresentation) {
 			description = new DelegatingResourceDescription();
-            description.addProperty("class");
-            description.addProperty("uuid");
+			description.addProperty("uuid");
 			description.addProperty("name");
 			description.addProperty("description");
 			description.addProperty("parameters");
@@ -106,7 +105,6 @@ public abstract class BaseDefinitionResource<T extends Definition> extends Metad
 		} 
 		else if (rep instanceof FullRepresentation) {
 			description = new DelegatingResourceDescription();
-            description.addProperty("class");
 			description.addProperty("uuid");
 			description.addProperty("name");
 			description.addProperty("description");


### PR DESCRIPTION
## The issue I worked on
See [https://issues.openmrs.org/browse/REPORT-879](https://issues.openmrs.org/browse/REPORT-879) 

## Description of what I changed:
Removed `class` property from `omod/src/main/java/org/openmrs/module/reportingrest/web/resource/BaseDefinitionResource.java`
